### PR TITLE
fix: use v-prefixed RustFS release URLs

### DIFF
--- a/rustfs.rb
+++ b/rustfs.rb
@@ -24,7 +24,7 @@ class Rustfs < Formula
 
   desc "High-performance distributed object storage written in Rust"
   homepage "https://rustfs.com"
-  url "https://github.com/#{GITHUB_REPO}/archive/refs/tags/#{VERSION}.tar.gz"
+  url "https://github.com/#{GITHUB_REPO}/archive/refs/tags/v#{VERSION}.tar.gz"
   sha256 "c45340775a34b221f151362ef252b2bab5c8ff80ad07b437566200117400a37f"
   license "Apache-2.0"
 
@@ -103,7 +103,7 @@ class Rustfs < Formula
     target = system_target
     sha256 = BINARIES[target]
     return [nil, nil] unless sha256
-    url = "https://github.com/#{GITHUB_REPO}/releases/download/#{VERSION}/rustfs-#{target}-v#{VERSION}.zip"
+    url = "https://github.com/#{GITHUB_REPO}/releases/download/v#{VERSION}/rustfs-#{target}-v#{VERSION}.zip"
     [url, sha256]
   end
 

--- a/scripts/update_formula.rb
+++ b/scripts/update_formula.rb
@@ -167,7 +167,7 @@ ENV['LATEST_VERSION'] = version
 version_file = File.expand_path('../.latest_version', __dir__)
 File.write(version_file, version)
 
-source_sha = compute_source_tarball_sha(REPO, version)
+source_sha = compute_source_tarball_sha(REPO, tag)
 artifacts_sha = compute_artifacts_sha_map(rel, version)
 
 changed = update_formula_file(FORMULA_PATH, version, source_sha, artifacts_sha)

--- a/test/rustfs_formula_urls_test.rb
+++ b/test/rustfs_formula_urls_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+class RustfsFormulaUrlsTest < Minitest::Test
+  FORMULA = File.expand_path('../rustfs.rb', __dir__)
+
+  def formula
+    @formula ||= File.read(FORMULA)
+  end
+
+  def test_source_archive_uses_prefixed_release_tag
+    assert_includes formula, 'archive/refs/tags/v#{VERSION}.tar.gz'
+  end
+
+  def test_binary_download_uses_prefixed_release_tag
+    assert_includes formula, 'releases/download/v#{VERSION}/rustfs-#{target}-v#{VERSION}.zip'
+  end
+end


### PR DESCRIPTION
## Summary
- Fix the RustFS formula source archive URL to use the v-prefixed release tag.
- Fix binary download URLs to use the v-prefixed GitHub release path while keeping Homebrew VERSION normalized without v.
- Have the updater compute the source tarball checksum from the actual release tag and add a regression test for URL templates.

## Verification
- ruby -Itest test/rustfs_formula_urls_test.rb
- ruby test/rustfs_formula_urls_test.rb
- ruby -c scripts/update_formula.rb
- ruby -c rustfs.rb
- git diff --check
- gh api repos/rustfs/rustfs/git/ref/tags/v1.0.0-beta.1
- gh release view v1.0.0-beta.1 --repo rustfs/rustfs --json tagName,assets

## Notes
- GITHUB_UPSTREAM_REPO=rustfs/rustfs ruby scripts/update_formula.rb could not complete locally because direct github.com asset download timed out with Net::OpenTimeout.
- curl HEAD checks to github.com release URLs also timed out from this machine.
- HOMEBREW_NO_AUTO_UPDATE=1 brew audit --strict --formula rustfs reaches audit but reports pre-existing formula style issues unrelated to this URL fix.
